### PR TITLE
Add a line break after artifact title and links

### DIFF
--- a/src/layouts/shortcodes/artifact-listing.html
+++ b/src/layouts/shortcodes/artifact-listing.html
@@ -17,7 +17,7 @@
       ]
     {{ end }}
 
-    <br/>
+    <br>
 
     {{ .authors }},
     {{ if isset . "venue" }} <i>{{ .venue }}</i>, {{ end }}


### PR DESCRIPTION
Add a line break in each artifact listing after the title + any links, so the author, date, and venue information is on its own line.

Per @bradcray 's suggestion.

[reviewer info placeholder]

Testing:
- [x] looks right in local build