### PR TITLE
Update website sources for Chapel 2.5 release

### DIFF
--- a/chapel-lang.org/handson.html
+++ b/chapel-lang.org/handson.html
@@ -16,31 +16,31 @@ you find something's gone stale since our last use of them.
 
 <li> <b>C-ray Ray Tracing</b> (data parallelism focus)
   <ul>
-     <li> <a href = "https://github.com/chapel-lang/chapel/blob/release/2.4/test/exercises/c-ray/README">README</a>
-     <li> <a href = "https://github.com/chapel-lang/chapel/blob/release/2.4/test/exercises/c-ray/c-ray.chpl">c-ray.chpl</a>
-     <li> <a href = "https://github.com/chapel-lang/chapel/blob/release/2.4/test/exercises/c-ray/CRayImage.chpl">CRayImage.chpl</a>
-     <li> <a href = "https://github.com/chapel-lang/chapel/blob/release/2.4/test/exercises/c-ray/Makefile">Makefile</a>
-     <li> <a href = "https://github.com/chapel-lang/chapel/blob/release/2.4/test/exercises/c-ray/scene">scene</a>
-     <li> <a href = "https://github.com/chapel-lang/chapel/blob/release/2.4/test/exercises/c-ray/sphfract">sphfract</a>
-     <li> <a href = "https://github.com/chapel-lang/chapel/blob/release/2.4/test/exercises/c-ray/scene.bmp">scene.bmp</a>
-     <li> <a href = "https://github.com/chapel-lang/chapel/blob/release/2.4/test/exercises/c-ray/sphfract.bmp">sphfract.bmp</a>
+     <li> <a href = "https://github.com/chapel-lang/chapel/blob/release/2.5/test/exercises/c-ray/README">README</a>
+     <li> <a href = "https://github.com/chapel-lang/chapel/blob/release/2.5/test/exercises/c-ray/c-ray.chpl">c-ray.chpl</a>
+     <li> <a href = "https://github.com/chapel-lang/chapel/blob/release/2.5/test/exercises/c-ray/CRayImage.chpl">CRayImage.chpl</a>
+     <li> <a href = "https://github.com/chapel-lang/chapel/blob/release/2.5/test/exercises/c-ray/Makefile">Makefile</a>
+     <li> <a href = "https://github.com/chapel-lang/chapel/blob/release/2.5/test/exercises/c-ray/scene">scene</a>
+     <li> <a href = "https://github.com/chapel-lang/chapel/blob/release/2.5/test/exercises/c-ray/sphfract">sphfract</a>
+     <li> <a href = "https://github.com/chapel-lang/chapel/blob/release/2.5/test/exercises/c-ray/scene.bmp">scene.bmp</a>
+     <li> <a href = "https://github.com/chapel-lang/chapel/blob/release/2.5/test/exercises/c-ray/sphfract.bmp">sphfract.bmp</a>
   </ul>
 
 <li> <b>Bounded Buffer Exercise</b> (task parallelism focus)
   <ul>
-    <li> <a href = "https://github.com/chapel-lang/chapel/blob/release/2.4/test/exercises/boundedBuffer/README">README</a>
-    <li> <a href = "https://github.com/chapel-lang/chapel/blob/release/2.4/test/exercises/boundedBuffer/boundedBuffer.chpl">boundedBuffer.chpl</a>
-    <li> <a href = "https://github.com/chapel-lang/chapel/blob/release/2.4/test/exercises/boundedBuffer/Makefile">Makefile</a>
+    <li> <a href = "https://github.com/chapel-lang/chapel/blob/release/2.5/test/exercises/boundedBuffer/README">README</a>
+    <li> <a href = "https://github.com/chapel-lang/chapel/blob/release/2.5/test/exercises/boundedBuffer/boundedBuffer.chpl">boundedBuffer.chpl</a>
+    <li> <a href = "https://github.com/chapel-lang/chapel/blob/release/2.5/test/exercises/boundedBuffer/Makefile">Makefile</a>
   </ul>
 
 <li> <b>Finding Duplicate Files</b>
   <ul>
-    <li> <a href = "https://github.com/chapel-lang/chapel/blob/release/2.4/test/exercises/duplicates/forStudents/README">README</a>
-    <li> <a href = "https://github.com/chapel-lang/chapel/blob/release/2.4/test/exercises/duplicates/forStudents/duplicates.chpl">duplicates.chpl</a>
-    <li> <a href = "https://github.com/chapel-lang/chapel/tree/release/2.4/test/exercises/duplicates/forStudents/example-files">example-files/</a>
-    <li> <a href = "https://github.com/chapel-lang/chapel/blob/release/2.4/test/exercises/duplicates/forStudents/expected-output">expected-output</a>
-    <li> <a href = "https://github.com/chapel-lang/chapel/blob/release/2.4/test/exercises/duplicates/forStudents/FileHashing.chpl">FileHashing.chpl</a>
-    <li> <a href = "https://github.com/chapel-lang/chapel/blob/release/2.4/test/exercises/duplicates/forStudents/SHA256Implementation.chpl">SHA256Implementation.chpl</a>
+    <li> <a href = "https://github.com/chapel-lang/chapel/blob/release/2.5/test/exercises/duplicates/forStudents/README">README</a>
+    <li> <a href = "https://github.com/chapel-lang/chapel/blob/release/2.5/test/exercises/duplicates/forStudents/duplicates.chpl">duplicates.chpl</a>
+    <li> <a href = "https://github.com/chapel-lang/chapel/tree/release/2.5/test/exercises/duplicates/forStudents/example-files">example-files/</a>
+    <li> <a href = "https://github.com/chapel-lang/chapel/blob/release/2.5/test/exercises/duplicates/forStudents/expected-output">expected-output</a>
+    <li> <a href = "https://github.com/chapel-lang/chapel/blob/release/2.5/test/exercises/duplicates/forStudents/FileHashing.chpl">FileHashing.chpl</a>
+    <li> <a href = "https://github.com/chapel-lang/chapel/blob/release/2.5/test/exercises/duplicates/forStudents/SHA256Implementation.chpl">SHA256Implementation.chpl</a>
   </ul>
 
 </ul>

--- a/src/config.toml
+++ b/src/config.toml
@@ -133,8 +133,8 @@ disableKinds = ['taxonomy', 'term']
 
 
 [params]
-    version="2.4"
-    versionURL="blog/posts/announcing-chapel-2.4/"
+    version="2.5"
+    versionURL="blog/posts/announcing-chapel-2.5/"
     mainSections = ["blog"]
 
     # Style options: default (light-blue), blue, green, marsala, pink, red, turquoise, violet

--- a/src/content/download.md
+++ b/src/content/download.md
@@ -7,7 +7,7 @@ keywords = ["TODO"]
 title="Downloading from Source"
 id="source"
 description="""
-To download and install Chapel from source, download **[chapel-2.4.0.tar.gz](https://github.com/chapel-lang/chapel/releases/download/2.4.0/chapel-2.4.0.tar.gz)** from [GitHub](https://github.com/chapel-lang/chapel/releases/tag/2.4.0), then unpack and build it as described in the [Quickstart instructions](https://chapel-lang.org/docs/usingchapel/QUICKSTART.html).
+To download and install Chapel from source, download **[chapel-2.5.0.tar.gz](https://github.com/chapel-lang/chapel/releases/download/2.5.0/chapel-2.5.0.tar.gz)** from [GitHub](https://github.com/chapel-lang/chapel/releases/tag/2.5.0), then unpack and build it as described in the [Quickstart instructions](https://chapel-lang.org/docs/usingchapel/QUICKSTART.html).
 """
 
 [[configurations]]
@@ -48,14 +48,15 @@ description="""
 title="Downloading on HPE Systems"
 id="hpe"
 description="""
-#### Using and Installing Chapel on HPE Cray EX and XC systems
+#### Using and Installing Chapel on HPE Cray EX systems
 
-Users of HPE Cray EX and XC systems can use Chapel as follows:
+Users of HPE Cray EX systems can use Chapel as follows:
 1. Load the Chapel module: `module load chapel`
 2. Read [$CHPL_HOME/doc/rst/platforms/cray.rst](https://chapel-lang.org/docs/platforms/cray.html) for quick-start instructions and more detailed notes.
-If these steps don't work, be sure that the latest version of Chapel (2.4) is installed on your system and ask your system administrator to install it if not. If the latest version doesn't work for you, send us a [bug report](https://chapel-lang.org/docs/usingchapel/bugs.html).
 
-#### Installing Chapel on HPE Apollo and Cray CS systems
+If these steps don't work, be sure that the latest version of Chapel (2.5) is installed on your system and ask your system administrator to [install it](https://myenterpriselicense.hpe.com/cwp-ui/software/Search?productCategory=Open%20Source&productInfo=Chapel_EX-OSP) if not. If the latest version doesn't work for you, send us a [bug report](https://chapel-lang.org/docs/usingchapel/bugs.html).
+
+#### Installing Chapel on HPE Apollo, Cray XC, and Cray CS systems
 Users of HPE Apollo or Cray CS systems should download Chapel and build from source, referring to [$CHPL_HOME/doc/rst/platforms/cray.rst](https://chapel-lang.org/docs/platforms/cray.html) for further details.
 """
 
@@ -69,9 +70,9 @@ id="linux"
 description="""
 We provide Chapel packages for several different Linux distributions, though they come with some performance caveats. They can be installed as follows:
 1. Download the package for your system using one of the following links:
-{{<pkg-list "2.4.0">}}
+{{<pkg-list "2.5.0">}}
 
-2. Check its SHA256 checksum using the values and instructions on the corresponding [GitHub release page](https://github.com/chapel-lang/chapel/releases/tag/2.4.0/).
+2. Check its SHA256 checksum using the values and instructions on the corresponding [GitHub release page](https://github.com/chapel-lang/chapel/releases/tag/2.5.0/).
 
 3. Install using the system package manager. 
   - For RPM based distributions (Fedora, RHEL, etc), use: `dnf install ./<chapel package name>`


### PR DESCRIPTION
This updates:
* config.toml: To list 2.5 as the new default
* download.md: To list 2.5 as the new default
* handson.html: To point to the 2.5 version of the hands-on directory

While here, I made some minor improvementes to the HPE/Cray section of the download page:

* added a download link for the HPE Cray EX RPM
* fixed some text that had gotten glommed into bullet 2 to follow it instead
* moved the Cray XC into the section with Apollo and CS since we don't release RPMs for it anymore
