### PR TITLE
added aliases to enable both capitalized and non-capitalized links.

### DIFF
--- a/src/content/chapelcon25/_index.md
+++ b/src/content/chapelcon25/_index.md
@@ -12,6 +12,10 @@ nav:
     section: "organization"
   - title: "Contact"
     section: "contact"
+aliases:
+- "/chapelcon2025"
+- "/ChapelCon25"
+- "/ChapelCon2025"
 ---
 
 {{< section "banner.md" >}}


### PR DESCRIPTION
Also adds full year versions. The redirection works correctly for me, on my mac, with hugo 0.145.0