### PR TITLE
Updates to the ChapelCon '25 Page

### DIFF
--- a/src/content/chapelcon25/_index.md
+++ b/src/content/chapelcon25/_index.md
@@ -12,6 +12,11 @@ nav:
     section: "organization"
   - title: "Contact"
     section: "contact"
+aliases:
+- "/chapelcon25"
+- "/ChapelCon25"
+- "/chapelcon2025"
+- "/ChapelCon2025"
 ---
 
 {{< section "banner.md" >}}

--- a/src/content/chapelcon25/_index.md
+++ b/src/content/chapelcon25/_index.md
@@ -12,11 +12,6 @@ nav:
     section: "organization"
   - title: "Contact"
     section: "contact"
-aliases:
-- "/chapelcon25"
-- "/ChapelCon25"
-- "/chapelcon2025"
-- "/ChapelCon2025"
 ---
 
 {{< section "banner.md" >}}

--- a/src/content/chapelcon25/banner.md
+++ b/src/content/chapelcon25/banner.md
@@ -7,5 +7,5 @@ Join us at _the_ annual [Chapel Programming Language](https://chapel-lang.org/)
 event to talk about the language, libraries, and applications! ChapelCon is 
 free to attend and will be held virtually.
 
-{{< button url="http://www.wikicfp.com/cfp/servlet/event.showcfp?eventid=188767"  >}}**Call for Papers**{{</button >}}
+{{< button url="http://www.wikicfp.com/cfp/servlet/event.showcfp?eventid=188767"  >}}**Call for Papers**{{</button >}}{{< button url="https://easychair.org/conferences/?conf=chapelcon25"  >}}**Submissions**{{</button >}}{{< button url="https://forms.cloud.microsoft/r/k2z5DuLLUM"  >}}**Office Hours Signup**{{</button >}}
 {{< /div >}}

--- a/src/content/chapelcon25/banner.md
+++ b/src/content/chapelcon25/banner.md
@@ -1,4 +1,5 @@
 ---
+headless: true
 ---
 {{< div "banner" >}}
 # ChapelCon '25

--- a/src/content/chapelcon25/contact.md
+++ b/src/content/chapelcon25/contact.md
@@ -1,4 +1,5 @@
 ---
+headless: true
 ---
 
 ## Contact

--- a/src/content/chapelcon25/days.md
+++ b/src/content/chapelcon25/days.md
@@ -1,4 +1,5 @@
 ---
+headless: true
 ---
 {{< sidebyside >}}
 {{% sidebysideelt %}}

--- a/src/content/chapelcon25/organization.md
+++ b/src/content/chapelcon25/organization.md
@@ -1,17 +1,20 @@
+---
+headless: true
+---
 ## Organization
 - __General Chair__: Brandon Neth, _Hewlett Packard Enterprise_
 - __Program Committee Chair__: Luca Ferranti, _Aalto University_
 - __Tutorial Days Chair__: Daniel Fedorin, _Hewlett Packard Enterprise_
 - __Office Hours Chair__: Jade Abraham, _Hewlett Packard Enterprise_
 #### Program Committee
-- Nelson Luis Dias, _Universidade Federal do Paraná_
+- Nelson Luis Dias, _Federal University of Paraná_
 - Dan Bonachea, _Lawrence Berkeley National Laboratory_
 - Oliver Alvarado Rodriguez, _Hewlett Packard Enterprise_
 - Stephen Olivier, _Sandia National Laboratories_
-- Bill Hadri, _King Abdullah University of Science and Technology_
+- Bilel Hadri, _King Abdullah University of Science and Technology_
 - Amanda Potts, _Datacraft Solutions_
-- Tom Westerhout, _Radbound University_
-- Sameer Shende, _University of Oregon_
+- Tom Westerhout, _Radboud University_
+- Sameer Shende, _University of Oregon & Paratools, Inc._
 - Rich Vuduc, _Georgia Institute of Technology_
 - Tiago Carneiro
 - Patrick Diehl, _Los Alamos National Laboratory_

--- a/src/content/chapelcon25/organization.md
+++ b/src/content/chapelcon25/organization.md
@@ -4,7 +4,17 @@
 - __Tutorial Days Chair__: Daniel Fedorin, _Hewlett Packard Enterprise_
 - __Office Hours Chair__: Jade Abraham, _Hewlett Packard Enterprise_
 #### Program Committee
-- Coming Soon
+- Nelson Luis Dias, _Universidade Federal do Paraná_
+- Dan Bonachea, _Lawrence Berkeley National Laboratory_
+- Oliver Alvarado Rodriguez, _Hewlett Packard Enterprise_
+- Stephen Olivier, _Sandia National Laboratories_
+- Bill Hadri, _King Abdullah University of Science and Technology_
+- Amanda Potts, _Datacraft Solutions_
+- Tom Westerhout, _Radbound University_
+- Sameer Shende, _University of Oregon_
+- Rich Vuduc, _Georgia Institute of Technology_
+- Tiago Carneiro
+- Patrick Diehl, _Los Alamos National Laboratory_
 #### Advisory Committee
  - Engin Kayraklıoğlu, _Hewlett Packard Enterprise_
  - Brad Chamberlain, _Hewlett Packard Enterprise_

--- a/src/content/chapelcon25/organization.md
+++ b/src/content/chapelcon25/organization.md
@@ -16,7 +16,7 @@ headless: true
 - Tom Westerhout, _Radboud University_
 - Sameer Shende, _University of Oregon & Paratools, Inc._
 - Rich Vuduc, _Georgia Institute of Technology_
-- Tiago Carneiro
+- Tiago Carneiro, _Chapel User_
 - Patrick Diehl, _Los Alamos National Laboratory_
 #### Advisory Committee
  - Engin Kayraklıoğlu, _Hewlett Packard Enterprise_

--- a/src/content/chapelcon25/session-details.md
+++ b/src/content/chapelcon25/session-details.md
@@ -1,3 +1,6 @@
+---
+headless: true
+---
 ## Sessions
 ### About Tutorial Days
 The first two days of ChapelCon '25 (October 7 and October 8) will focus on action. Each day will begin with a guided tutorial, followed by hands-on exercises in the group, followed by free coding sessions, where participants can work on their own applications or on provided project prompts. 

--- a/src/content/chapelcon25/summary-and-timeline.md
+++ b/src/content/chapelcon25/summary-and-timeline.md
@@ -1,4 +1,5 @@
 ---
+headless: true
 ---
 
 ChapelCon '25 welcomes anyone with computing challenges that demand performance, particularly through parallelism and scalability. ChapelCon '25 brings together Chapel users, enthusiasts, researchers, and developers to exchange ideas, present their work, and forge new collaborations. Anyone interested in parallel programming, programming languages, or high performance computing is encouraged to attend. A wide range of sessions support all levels of experience, with Tutorials and Free Coding sessions for those looking to hone their skills, Office Hour sessions for those looking for help from Chapel developers, and Conference sessions for those looking to share and discuss their work. **ChapelCon '25 is free to attend and will be held virtually.**
@@ -7,9 +8,9 @@ ChapelCon '25 welcomes anyone with computing challenges that demand performance,
 * __June 25__: CFP Released
 * __June 27__: Submissions Open
 * __July 15__: [ChapelCon AMA, 10AM Pacific](https://teams.microsoft.com/l/meetup-join/19%3ameeting_N2M5M2E2NTEtNTFkMi00ZjA1LThiNDQtMjFjY2U2ZDc5ODk3%40thread.v2/0?context=%7b%22Tid%22%3a%22105b2061-b669-4b31-92ac-24d304d195dc%22%2c%22Oid%22%3a%22bef28eea-6179-4f21-b284-84c6a0aeacc3%22%7d)
-* __July 22__: [ChapelCon Night of Unfinished Abstracts, 10AM Pacific](https://teams.microsoft.com/l/meetup-join/19%3ameeting_N2M5M2E2NTEtNTFkMi00ZjA1LThiNDQtMjFjY2U2ZDc5ODk3%40thread.v2/0?context=%7b%22Tid%22%3a%22105b2061-b669-4b31-92ac-24d304d195dc%22%2c%22Oid%22%3a%22bef28eea-6179-4f21-b284-84c6a0aeacc3%22%7d)
-* __July 25__: Submissions Due
-* __August 26__: Acceptance Notifications
+* __July 31__: [ChapelCon Night of Unfinished Submissions, 10AM Pacific](https://teams.microsoft.com/l/meetup-join/19%3ameeting_N2M5M2E2NTEtNTFkMi00ZjA1LThiNDQtMjFjY2U2ZDc5ODk3%40thread.v2/0?context=%7b%22Tid%22%3a%22105b2061-b669-4b31-92ac-24d304d195dc%22%2c%22Oid%22%3a%22bef28eea-6179-4f21-b284-84c6a0aeacc3%22%7d)
+* __August 8__: Submissions Due
+* __September 2__: Acceptance Notifications
 * __September 23__: Office Hours Requests Due
 * __October 7-8__: ChapelCon '25 Tutorial Days
 * __October 9-10__: ChapelCon '25 Conference Days

--- a/src/content/chapelcon25/summary-and-timeline.md
+++ b/src/content/chapelcon25/summary-and-timeline.md
@@ -6,6 +6,8 @@ ChapelCon '25 welcomes anyone with computing challenges that demand performance,
 ## Timeline
 * __June 25__: CFP Released
 * __June 27__: Submissions Open
+* __July 15__: [ChapelCon AMA, 10AM Pacific](https://teams.microsoft.com/l/meetup-join/19%3ameeting_N2M5M2E2NTEtNTFkMi00ZjA1LThiNDQtMjFjY2U2ZDc5ODk3%40thread.v2/0?context=%7b%22Tid%22%3a%22105b2061-b669-4b31-92ac-24d304d195dc%22%2c%22Oid%22%3a%22bef28eea-6179-4f21-b284-84c6a0aeacc3%22%7d)
+* __July 22__: [ChapelCon Night of Unfinished Abstracts, 10AM Pacific](https://teams.microsoft.com/l/meetup-join/19%3ameeting_N2M5M2E2NTEtNTFkMi00ZjA1LThiNDQtMjFjY2U2ZDc5ODk3%40thread.v2/0?context=%7b%22Tid%22%3a%22105b2061-b669-4b31-92ac-24d304d195dc%22%2c%22Oid%22%3a%22bef28eea-6179-4f21-b284-84c6a0aeacc3%22%7d)
 * __July 25__: Submissions Due
 * __August 26__: Acceptance Notifications
 * __September 23__: Office Hours Requests Due

--- a/src/content/chapelcon25/summary-and-timeline.md
+++ b/src/content/chapelcon25/summary-and-timeline.md
@@ -8,8 +8,10 @@ ChapelCon '25 welcomes anyone with computing challenges that demand performance,
 * __June 25__: CFP Released
 * __June 27__: Submissions Open
 * __July 15__: [ChapelCon AMA, 10AM Pacific](https://teams.microsoft.com/l/meetup-join/19%3ameeting_N2M5M2E2NTEtNTFkMi00ZjA1LThiNDQtMjFjY2U2ZDc5ODk3%40thread.v2/0?context=%7b%22Tid%22%3a%22105b2061-b669-4b31-92ac-24d304d195dc%22%2c%22Oid%22%3a%22bef28eea-6179-4f21-b284-84c6a0aeacc3%22%7d)
+* ~~__July 25__: Submissions Due~~
 * __July 31__: [ChapelCon Night of Unfinished Submissions, 10AM Pacific](https://teams.microsoft.com/l/meetup-join/19%3ameeting_N2M5M2E2NTEtNTFkMi00ZjA1LThiNDQtMjFjY2U2ZDc5ODk3%40thread.v2/0?context=%7b%22Tid%22%3a%22105b2061-b669-4b31-92ac-24d304d195dc%22%2c%22Oid%22%3a%22bef28eea-6179-4f21-b284-84c6a0aeacc3%22%7d)
 * __August 8__: Submissions Due
+* ~~__August 26__: Acceptance Notifications~~
 * __September 2__: Acceptance Notifications
 * __September 23__: Office Hours Requests Due
 * __October 7-8__: ChapelCon '25 Tutorial Days


### PR DESCRIPTION
This PR adds:
- a button for signing up for office hours
- the AMA and NoUA events to the timeline
- the PC
- page aliases within the hugo source 
