### PR TITLE
ChapelCon page: visual tweaks

### DIFF
--- a/src/content/chapelcon25/_index.md
+++ b/src/content/chapelcon25/_index.md
@@ -19,12 +19,11 @@ nav:
 ---
 
 {{< section "banner.md" >}}
-
 {{< section "summary.md" "white" >}}
 {{< section "keynote.md">}}
 {{< section "invited.md">}}
-{{< section "program.md">}}
-{{< section "days.md" "white">}}
+{{< section "program.md" "white program" >}}
+{{< section "days.md" >}}
 {{< section "timeline.md" "white" >}}
 {{< section "session-details.md" "white" >}}
 {{< section "organization.md" "white" >}}

--- a/src/content/chapelcon25/program.md
+++ b/src/content/chapelcon25/program.md
@@ -1,9 +1,9 @@
 ---
 headless: true
 ---
-### Program
+## Program
 
-## October 7: Tutorials, Day 1
+### October 7: Tutorials, Day 1
 
 
 {{< session-table >}}
@@ -17,7 +17,7 @@ headless: true
 {{< chapelcon-session "freecode1" >}}
 {{< /session-table >}}
 
-## October 8: Tutorials, Day 2
+### October 8: Tutorials, Day 2
 
 {{< session-table >}}
 {{< chapelcon-session "welcome2" >}}
@@ -28,7 +28,7 @@ headless: true
 {{< chapelcon-session "iterators-demo" >}}
 {{< /session-table >}}
 
-## October 9: Conference, Day 1
+### October 9: Conference, Day 1
 {{< session-table >}}
 {{< chapelcon-session "welcome3" >}}
 {{< chapelcon-session "chai" >}}
@@ -49,7 +49,8 @@ headless: true
 {{< chapelcon-session "discussion" >}}
 
 {{< /session-table >}}
-## October 10: Conference, Day 2
+
+### October 10: Conference, Day 2
 
 {{< session-table >}}
 {{< chapelcon-session "welcome4" >}}

--- a/src/themes/hugo-universal-theme/layouts/chapelcon/section.html
+++ b/src/themes/hugo-universal-theme/layouts/chapelcon/section.html
@@ -26,14 +26,14 @@
             background-color: rgba(255, 255, 255, 0.8);
             padding: 1em;
             border: 0.05em solid #fafafa;
-            border-radius: 0.15em;
+            border-radius: 0.4em;
             max-width: 40rem;
             box-sizing: border-box;
             box-shadow: 0 0 0.5rem rgba(0, 0, 0, 0.2);
 
             font-size: 1.2rem;
-            margin-bottom: 7rem;
-            margin-top: 7rem;
+            margin-bottom: 3rem;
+            margin-top: 3rem;
         }
 
         .banner.wide {
@@ -46,9 +46,9 @@
         }
 
         .banner.wide img {
-            border-radius: 0.4rem;
+            border-radius: 50%;
             max-width: 10em;
-            padding-bottom: 0.0em;
+            margin-right: 1em;
         }
 
         h1 {
@@ -56,7 +56,7 @@
             margin-bottom: 0.25em;
         }
 
-        h2 {
+        .keynote h2 {
             font-size: 2.5rem;
             margin-top: 0;
             margin-bottom: 0.25em;
@@ -74,6 +74,10 @@
         }
         p {
             font-size: 1.3rem;
+        }
+
+        figure {
+            margin: 0;
         }
 
         li {
@@ -116,6 +120,7 @@
             font-size: 1.2rem;
 
             transition: background-color 0.2s;
+            margin-right: 0.2em;
         }
 
         a.button:hover {
@@ -135,44 +140,48 @@
             padding: 2rem;
         }
 
+        /* for this section, invert the size of the h2 and h3 */
+        section.program h2 {
+            font-size: 1.8rem;
+        }
+
+        section.program h3 {
+            font-size: 2.5rem;
+            margin-top: 2rem;
+        }
+
         .side-by-side {
             display: flex;
         }
 
         .element {
-            border: 0.075rem solid rgba(0, 0, 0, 0.15);
             border-radius: 0.4rem;
             padding: 2rem;
             flex-grow: 1;
             flex-basis: 0;
             margin: 1rem;
-            background-color: rgba(255, 255, 255, 0.8);
             box-shadow: 0 0 0.5rem rgba(0, 0, 0, 0.2);
+            background-color: white;
         }
 
         .element.small {
             flex-grow: 0;
         }
 
-        .banner > .side-by-side > .element > figure {
-            margin: 0;
-            padding: 0;
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-            height: 100%;
-        }
         .banner > .side-by-side {
             align-items: center;
         }
-        
+
         .banner > .side-by-side .element {
             border: none;
-            padding: 0;
+            box-shadow: none;
+            background-color: transparent;
+            padding: 0.25em;
+            margin-top: 0;
         }
 
         img {
-            border-radius: 0.2rem;
+            border-radius: 0.4rem;
         }
 
         .element:first-child {
@@ -242,29 +251,6 @@
             font-size: 1.1em;
             margin-bottom: 0.4em;
             max-width: 800px;
-        }
-
-        .side-by-side .element p {
-            padding: 0.5em;
-        }
-        .side-by-side .element h2 {
-            padding-left: 15px;
-            padding-right: 15px;
-        }
-        .side-by-side .element h3 {
-            padding-left: 15px;
-            padding-right: 15px;
-        }
-        .side-by-side .element h4 {
-            padding-left: 15px;
-            padding-right: 15px;
-        }
-
-        th {
-            text-align: right;
-            font-weight: bold;
-            font-size: 1.2em;
-            padding-right: 1em;
         }
 
     </style>

--- a/src/themes/hugo-universal-theme/layouts/chapelcon/section.html
+++ b/src/themes/hugo-universal-theme/layouts/chapelcon/section.html
@@ -2,6 +2,7 @@
 <html lang="{{ .Site.LanguageCode }}">
 
   <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <style>
         body {
             background-image: url("{{ page.Resources.Get (page.Params.image) }}");
@@ -17,9 +18,20 @@
         }
 
         .container {
-            max-width: 80rem;
+            max-width: 1280px;
             box-sizing: border-box;
             margin: auto;
+        }
+
+        @media (max-width: 1280px) {
+            .container {
+                padding-left: 1rem;
+                padding-right: 1rem;
+            }
+
+            .side-by-side {
+                flex-direction: column;
+            }
         }
 
         .banner {
@@ -112,6 +124,7 @@
         }
 
         a.button {
+            display: inline-block;
             background-color: white;
             color: black;
             border: 0.1em solid rgba(0, 0, 0, 0.15);
@@ -121,6 +134,7 @@
 
             transition: background-color 0.2s;
             margin-right: 0.2em;
+            margin-bottom: 0.2em;
         }
 
         a.button:hover {


### PR DESCRIPTION
Makes some visual tweaks to the ChapelCon page.

Also greatly improves rendering on mobile devices.

## Before
<img width="797" height="752" alt="Screenshot 2025-09-24 at 2 54 07 PM" src="https://github.com/user-attachments/assets/300bc3ef-c699-487b-863b-8e5a4e28041d" />
<img width="704" height="390" alt="Screenshot 2025-09-24 at 2 54 12 PM" src="https://github.com/user-attachments/assets/8f0e6752-d6ae-4648-ae14-7e4f5939ef67" />
<img width="1031" height="686" alt="Screenshot 2025-09-24 at 2 54 02 PM" src="https://github.com/user-attachments/assets/16d7eca5-ea14-481f-ac3d-0d38d088f9d0" />

## After
<img width="991" height="713" alt="Screenshot 2025-09-24 at 2 53 37 PM" src="https://github.com/user-attachments/assets/8f9d0532-f0d5-40f3-9367-d0590c2bfd4e" />
<img width="787" height="745" alt="Screenshot 2025-09-24 at 2 53 43 PM" src="https://github.com/user-attachments/assets/88f681d0-d687-403e-a6df-6cad971ea5cd" />
<img width="709" height="422" alt="Screenshot 2025-09-24 at 2 53 55 PM" src="https://github.com/user-attachments/assets/62dc190e-196b-497c-9fe1-8165d08f7ba3" />


Visually checked with @brandon-neth -- thanks!