### PR TITLE
Add anchor link after each artifact by its slug

### DIFF
--- a/src/layouts/shortcodes/artifact-listing.html
+++ b/src/layouts/shortcodes/artifact-listing.html
@@ -1,8 +1,10 @@
 {{$var := .Get 0}}
 {{$summary := .Get 1 }}
 
+{{$anchor-id := "artifact-$var" }}
+
 {{ with index .Site.Data.artifacts $var }}
-  <div class="publication" id="artifact-{{ $var }}">
+  <div class="publication" id="{{ $anchor-id }}">
     {{ if isset . "url" }} <a href="{{ .url }}"> {{ end }}
     <b>{{ .title }}</b>
     {{ if isset . "url" }} </a> {{ end }}
@@ -17,7 +19,7 @@
       ]
     {{ end }}
 
-    <a href="#artifact-{{ $var }}">&#128279;</a>
+    <a href="#{{ $anchor-id }}">&#128279;</a>
 
     <br>
 

--- a/src/layouts/shortcodes/artifact-listing.html
+++ b/src/layouts/shortcodes/artifact-listing.html
@@ -1,7 +1,7 @@
 {{$var := .Get 0}}
 {{$summary := .Get 1 }}
 
-{{$anchor_id := "artifact-$var" }}
+{{$anchor_id := printf "%s%s" "artifact-" $var }}
 
 {{ with index .Site.Data.artifacts $var }}
   <div class="publication" id="{{ $anchor_id }}">

--- a/src/layouts/shortcodes/artifact-listing.html
+++ b/src/layouts/shortcodes/artifact-listing.html
@@ -2,7 +2,7 @@
 {{$summary := .Get 1 }}
 
 {{ with index .Site.Data.artifacts $var }}
-  <div class="publication" id="{{ $var }}">
+  <div class="publication" id="artifact-{{ $var }}">
     {{ if isset . "url" }} <a href="{{ .url }}"> {{ end }}
     <b>{{ .title }}</b>
     {{ if isset . "url" }} </a> {{ end }}
@@ -17,7 +17,7 @@
       ]
     {{ end }}
 
-    <a href="#{{ $var }}">&#128279;</a>
+    <a href="#artifact-{{ $var }}">&#128279;</a>
 
     <br>
 

--- a/src/layouts/shortcodes/artifact-listing.html
+++ b/src/layouts/shortcodes/artifact-listing.html
@@ -2,7 +2,7 @@
 {{$summary := .Get 1 }}
 
 {{ with index .Site.Data.artifacts $var }}
-  <div class="publication">
+  <div class="publication" id="{{ $var }}">
     {{ if isset . "url" }} <a href="{{ .url }}"> {{ end }}
     <b>{{ .title }}</b>
     {{ if isset . "url" }} </a> {{ end }}
@@ -16,6 +16,8 @@
       {{ if isset . "extraLink" }} <a href="{{ .extraLink }}"> {{ .extraLinkText }} </a> {{ end }}
       ]
     {{ end }}
+
+    <a href="#{{ $var }}">&#128279;</a>
 
     <br>
 

--- a/src/layouts/shortcodes/artifact-listing.html
+++ b/src/layouts/shortcodes/artifact-listing.html
@@ -1,10 +1,10 @@
 {{$var := .Get 0}}
 {{$summary := .Get 1 }}
 
-{{$anchor-id := "artifact-$var" }}
+{{$anchor_id := "artifact-$var" }}
 
 {{ with index .Site.Data.artifacts $var }}
-  <div class="publication" id="{{ $anchor-id }}">
+  <div class="publication" id="{{ $anchor_id }}">
     {{ if isset . "url" }} <a href="{{ .url }}"> {{ end }}
     <b>{{ .title }}</b>
     {{ if isset . "url" }} </a> {{ end }}
@@ -19,7 +19,7 @@
       ]
     {{ end }}
 
-    <a href="#{{ $anchor-id }}">&#128279;</a>
+    <a href="#{{ $anchor_id }}">&#128279;</a>
 
     <br>
 


### PR DESCRIPTION
Add an anchor link/permalink icon to each artifact on the resource pages at the end of the title line. Linking is unique by artifact slug, which is used as the `id` of the containing `div` for the listing.

<img width="690" height="85" alt="image" src="https://github.com/user-attachments/assets/99f5b9cd-7936-4f85-a013-83f4c03ecc22" />

Resolves https://github.com/chapel-lang/chapel-www/issues/74.

[reviewer info placeholder]

Testing:
- In Firefox and Chrome:
  - clicking the link icon:
    - [x] changes the URL bar to include the slug anchor
    - [x] jumps the browser down to the title line
  - [x] visiting such a link from a new tab jumps down to the title line
  - ~~[ ] reloading while at an anchor link URL jumps down to the title line~~