### PR TITLE
Highlight permalinked-to artifact in yellow

### DIFF
--- a/src/layouts/shortcodes/artifact-listing.html
+++ b/src/layouts/shortcodes/artifact-listing.html
@@ -4,7 +4,7 @@
 {{- $anchor_id := printf "%s%s" "artifact-" $var -}}
 
 {{- with index .Site.Data.artifacts $var -}}
-  <div class="publication" id="{{- $anchor_id -}}">
+  <div class="artifact-listing" id="{{- $anchor_id -}}">
     {{- $artifact_data := . -}}
     <b>{{- .title -}}</b>
 

--- a/src/static/css/custom.css
+++ b/src/static/css/custom.css
@@ -584,3 +584,9 @@ td {
   color: var(--chapel-green);
   text-decoration: none;
 }
+
+/* ── Highlight targeted publication ── */
+div.publication:target {
+  background-color:#ff9;
+  border-radius:1rem
+}

--- a/src/static/css/custom.css
+++ b/src/static/css/custom.css
@@ -586,7 +586,7 @@ td {
 }
 
 /* ── Highlight targeted publication ── */
-div.publication:target {
+div.artifact-listing:target {
   background-color:#ff9;
   border-radius:1rem
 }


### PR DESCRIPTION
Add yellow highlighting to the `:target` artifact when following a permalink to it.

The result looks like this:
<img width="879" height="226" alt="Image" src="https://github.com/user-attachments/assets/2431137e-e17c-4603-ac7e-a29155f7f79e" />

Just copied the [logic from the blog SCSS](https://github.com/chapel-lang/chapel-blog/blob/4572b2c7cdaa92c771a9479437a1cb2792f16952/themes/chapel-theme/assets/scss/style.scss#L34-L37) into the website's plain CSS `custom.css`, and targeted to just `div.publication` to avoid unintended effects.

Resolves https://github.com/chapel-lang/chapel-www/issues/103.

[reviewer info placeholder]