### PR TITLE
Fix some deprecation warnings on build

### DIFF
--- a/src/config.toml
+++ b/src/config.toml
@@ -3,7 +3,7 @@ title = "The Chapel Programming Language"
 
 theme = "hugo-universal-theme"
 themesDir = "themes"
-languageCode = "en-us"
+locale = "en-us"
 # Site language. Available translations in the theme's `/i18n` directory.
 defaultContentLanguage = "en"
 

--- a/src/layouts/index.html
+++ b/src/layouts/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}">
+<html lang="{{ .Site.Language.Locale }}">
 
   <head>
     {{ partial "headers.html" . }}

--- a/src/layouts/partials/announcements.html
+++ b/src/layouts/partials/announcements.html
@@ -6,8 +6,8 @@
       </div>
      
       <!-- Merge the blog posts (.rss) and the manual announcements (.announcements)-->
-      {{ $posts := .Site.Data.rss }}
-      {{ range $fileName, $postData := .Site.Data.announcements }}
+      {{ $posts := hugo.Data.rss }}
+      {{ range $fileName, $postData := hugo.Data.announcements }}
         {{ $posts = $posts | append $postData }}
       {{ end }}
       {{ $posts := sort $posts "date" "desc"}}

--- a/src/layouts/partials/applications.html
+++ b/src/layouts/partials/applications.html
@@ -11,7 +11,7 @@
               data-autoplay="{{ default false .Site.Params.CarouselHomepage.auto_play }}"
               data-slide-speed="2000"
               data-pagination-speed="500">
-              {{ $apps := sort .Site.Data.applications "weight" }}
+              {{ $apps := sort hugo.Data.applications "weight" }}
                     {{ range $apps }}
               <div class="item">
                   {{ if .href }}

--- a/src/layouts/partials/attributes.html
+++ b/src/layouts/partials/attributes.html
@@ -1,11 +1,11 @@
 {{ if isset .Site.Params "attributes" }}
 {{ if .Site.Params.attributes.enable }}
-{{ if isset .Site.Data "attributes" }}
-{{ if gt (len .Site.Data.attributes) 0 }}
+{{ if isset hugo.Data "attributes" }}
+{{ if gt (len hugo.Data.attributes) 0 }}
 <section class="bar background-navy">
     <div class="container">
         {{ $elements := default 1 .Site.Params.attributes.cols }}
-        {{ $attributes := sort .Site.Data.attributes "weight" }}
+        {{ $attributes := sort hugo.Data.attributes "weight" }}
         {{ $total_rows := div (len $attributes) $elements }}
 
         {{ if gt (mod (len $attributes) $elements) 0 }}

--- a/src/layouts/partials/topgrid.html
+++ b/src/layouts/partials/topgrid.html
@@ -1,11 +1,11 @@
 {{ if isset .Site.Params "topgrid" }}
 {{ if .Site.Params.topgrid.enable }}
-{{ if isset .Site.Data "topgrid" }}
-{{ if gt (len .Site.Data.topgrid) 0 }}
+{{ if isset hugo.Data "topgrid" }}
+{{ if gt (len hugo.Data.topgrid) 0 }}
 <section class="try-get-learn background-white">
     <div class="container">
         {{ $elements := default 3 .Site.Params.topgrid.cols }}
-        {{ $topgrid := sort .Site.Data.topgrid "weight" }}
+        {{ $topgrid := sort hugo.Data.topgrid "weight" }}
 
         {{ $total_rows := div (len $topgrid) $elements }}
 

--- a/src/layouts/shortcodes/artifact-listing.html
+++ b/src/layouts/shortcodes/artifact-listing.html
@@ -3,7 +3,7 @@
 
 {{- $anchor_id := printf "%s%s" "artifact-" $var -}}
 
-{{- with index .Site.Data.artifacts $var -}}
+{{- with index hugo.Data.artifacts $var -}}
   <div class="artifact-listing" id="{{- $anchor_id -}}">
     {{- $artifact_data := . -}}
     <b>{{- .title -}}</b>

--- a/src/layouts/shortcodes/chapelcon-session.html
+++ b/src/layouts/shortcodes/chapelcon-session.html
@@ -1,7 +1,7 @@
 {{$var := .Get 0}}
 {{$summary := .Get 1 }}
 
-{{ with index .Site.Data.chapelcon25 $var }}
+{{ with index hugo.Data.chapelcon25 $var }}
 
 <tr>
 

--- a/src/layouts/shortcodes/pkg-list.html
+++ b/src/layouts/shortcodes/pkg-list.html
@@ -1,5 +1,5 @@
 {{ $version := .Get 0 }}
-{{ $OSes := .Site.Data.pkgs.pkgConfigs }}
+{{ $OSes := hugo.Data.pkgs.pkgConfigs }}
 
 <ul>
 {{ range $OSes }}

--- a/src/themes/hugo-universal-theme/layouts/404.html
+++ b/src/themes/hugo-universal-theme/layouts/404.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}">
+<html lang="{{ .Site.Language.Locale }}">
 
   <head>
     {{ partial "headers.html" . }}

--- a/src/themes/hugo-universal-theme/layouts/_default/list.html
+++ b/src/themes/hugo-universal-theme/layouts/_default/list.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}">
+<html lang="{{ .Site.Language.Locale }}">
 
   <head>
     {{ partial "headers.html" . }}

--- a/src/themes/hugo-universal-theme/layouts/_default/single.html
+++ b/src/themes/hugo-universal-theme/layouts/_default/single.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}">
+<html lang="{{ .Site.Language.Locale }}">
 
   <head>
     {{ partial "headers.html" . }}

--- a/src/themes/hugo-universal-theme/layouts/chapelcon/section.html
+++ b/src/themes/hugo-universal-theme/layouts/chapelcon/section.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}">
+<html lang="{{ .Site.Language.Locale }}">
 
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/src/themes/hugo-universal-theme/layouts/page/single.html
+++ b/src/themes/hugo-universal-theme/layouts/page/single.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}">
+<html lang="{{ .Site.Language.Locale }}">
 
   <head>
     {{ partial "headers.html" . }}

--- a/src/themes/hugo-universal-theme/layouts/partials/applications.html
+++ b/src/themes/hugo-universal-theme/layouts/partials/applications.html
@@ -1,6 +1,6 @@
 {{ if .Site.Params.applications.enable }}
-{{ if isset .Site.Data "applications" }}
-{{ if gt (len .Site.Data.applications) 0 }}
+{{ if isset hugo.Data "applications" }}
+{{ if gt (len hugo.Data.applications) 0 }}
 <section class="bar background-pentagon no-mb">
     <div class="container">
         <div class="row">
@@ -20,7 +20,7 @@
                     data-autoplay="{{ default false .Site.Params.CarouselApplications.auto_play }}"
                     data-slide-speed="{{ default 2000 .Site.Params.CarouselApplications.slide_speed }}"
                     data-pagination-speed="{{ default 1000 .Site.Params.CarouselApplications.pagination_speed }}">
-                    {{ $apps := sort .Site.Data.applications "weight" }}
+                    {{ $apps := sort hugo.Data.applications "weight" }}
                     {{ range $apps }}
                     <li class="item">
                         <div class="application same-height-always">

--- a/src/themes/hugo-universal-theme/layouts/partials/carousel.html
+++ b/src/themes/hugo-universal-theme/layouts/partials/carousel.html
@@ -1,6 +1,6 @@
 {{ if default true .Site.Params.CarouselHomepage.enable }}
-{{ if isset .Site.Data "carousel" }}
-{{ if gt (len .Site.Data.carousel) 0 }}
+{{ if isset hugo.Data "carousel" }}
+{{ if gt (len hugo.Data.carousel) 0 }}
 <section>
     <div class="home-carousel">
         <div class="dark-mask"></div>
@@ -9,7 +9,7 @@
                 data-autoplay="{{ default true .Site.Params.CarouselHomepage.auto_play }}"
                 data-slide-speed="{{ default 2000 .Site.Params.CarouselHomepage.slide_speed }}"
                 data-pagination-speed="{{ default 1000 .Site.Params.CarouselHomepage.pagination_speed }}">
-                {{ range sort .Site.Data.carousel "weight" }}
+                {{ range sort hugo.Data.carousel "weight" }}
                 <div class="item">
                     {{ if .href }}
                     <a href="{{ .href }}" target="_blank" title="{{ .title | safeHTML }}">

--- a/src/themes/hugo-universal-theme/layouts/partials/clients.html
+++ b/src/themes/hugo-universal-theme/layouts/partials/clients.html
@@ -1,7 +1,7 @@
 {{ if isset .Site.Params "clients" }}
 {{ if .Site.Params.clients.enable }}
-{{ if isset .Site.Data "clients" }}
-{{ if gt (len .Site.Data.clients) 0 }}
+{{ if isset hugo.Data "clients" }}
+{{ if gt (len hugo.Data.clients) 0 }}
 <section class="bar background-gray no-mb">
     <div class="container">
         <div class="row">
@@ -19,7 +19,7 @@
                     data-autoplay="{{ default false .Site.Params.CarouselCustomers.auto_play }}"
                     data-slide-speed="{{ default 2000 .Site.Params.CarouselCustomers.slide_speed }}"
                     data-pagination-speed="{{ default 1000 .Site.Params.CarouselCustomers.pagination_speed }}">
-                    {{ range .Site.Data.clients }}
+                    {{ range hugo.Data.clients }}
                     <li class="item" title="{{ .name }}">
                         {{ if .url }}
                           <a href="{{ .url }}" target="_blank">

--- a/src/themes/hugo-universal-theme/layouts/partials/headers.html
+++ b/src/themes/hugo-universal-theme/layouts/partials/headers.html
@@ -61,7 +61,7 @@
 {{ $is_valid_image := print "static/" $image | fileExists }}
 {{ if $is_valid_image }}
 {{ $image_ext := path.Ext $image }}
-<meta property="og:locale" content="{{ replace .Site.LanguageCode "-" "_" }}">
+<meta property="og:locale" content="{{ replace .Site.Language.Locale "-" "_" }}">
 <meta property="og:site_name" content="{{ .Site.Title }}">
 <meta property="og:title" content="{{ $title_plain }}">
 <meta property="og:type" content="{{ cond $is_blog "article" "website" }}">

--- a/src/themes/hugo-universal-theme/layouts/partials/recent_posts.html
+++ b/src/themes/hugo-universal-theme/layouts/partials/recent_posts.html
@@ -13,9 +13,9 @@
             </p>
 
             <!-- *** BLOG HOMEPAGE *** -->
-            {{ $posts := .Site.Data.rss }}
+            {{ $posts := hugo.Data.rss }}
 
-            {{ range $fileName, $postData := .Site.Data.announcements }}
+            {{ range $fileName, $postData := hugo.Data.announcements }}
                 {{ $posts = $posts | append $postData }}
             {{ end }}
             


### PR DESCRIPTION
Address the following deprecation warnings I get when building locally:
- `WARN  deprecated: project config key languageCode was deprecated in Hugo v0.158.0 and will be removed in a future release. Use locale instead.`
- `WARN  deprecated: .Site.LanguageCode was deprecated in Hugo v0.158.0 and will be removed in a future release. Use .Site.Language.Locale instead.`
- `WARN  deprecated: .Site.Data was deprecated in Hugo v0.156.0 and will be removed in a future release. Use
hugo.Data instead.`

[trivial, not reviewed]

Testing:
- [x] diff of generated site from `main` vs this PR is empty
- [x] `hugo build`