### PR TITLE
Print git status and diff after GA Hugo build

### DIFF
--- a/.github/workflows/hugo-build.yml
+++ b/.github/workflows/hugo-build.yml
@@ -21,4 +21,4 @@ jobs:
           git status
       - name: git diff
         run: |
-          git diff
+          git diff --color

--- a/.github/workflows/hugo-build.yml
+++ b/.github/workflows/hugo-build.yml
@@ -19,6 +19,6 @@ jobs:
       - name: git status
         run: |
           git status
-      - name: git diff
+      - name: git diff (non-deleted)
         run: |
-          git diff --color
+          git diff --color  --diff-filter=d

--- a/.github/workflows/hugo-build.yml
+++ b/.github/workflows/hugo-build.yml
@@ -16,3 +16,9 @@ jobs:
       - name: run make www
         run: |
           make -C ./src www
+      - name: git status
+        run: |
+          git status
+      - name: git diff
+        run: |
+          git diff


### PR DESCRIPTION
Run `git status` and `git diff` after building in the Hugo build Github Actions workflow, to see the resulting changes.

Inspired by weird build output differences across machines in https://github.com/chapel-lang/chapel-www/pull/108#issuecomment-4425274617, to give us results from a more "pure" environment.

[reviewed by @DanilaFe]

Testing:
- [x] check run output on this PR looks good