### PR TITLE
Shrink and re-align logo

### DIFF
--- a/src/static/css/custom.css
+++ b/src/static/css/custom.css
@@ -357,8 +357,8 @@ a:hover .social-name {
 }
 .navbar-brand img {
   max-height: 80px;
-  height: 70px;
-  margin-top: 3px;
+  height: 55px;
+  margin-top: 12px;
 }
 
 .navbar-nav {


### PR DESCRIPTION
I hadn't noticed until demo-ing this morning, but in the recent changes to the menu bar on the website, we'd reached a point where the menu wrapped to a separate line than the logo.  This takes the short-term fix of shrinking the logo a bit and re-aligning it to keep it on the same line.
