### PR TITLE
Add a test page for Chapel networking tests to pull from

### DIFF
--- a/chapel-lang.org/robots.txt
+++ b/chapel-lang.org/robots.txt
@@ -39,6 +39,7 @@ Disallow: /docs/latest/
 Disallow: /docs/main/
 Disallow: /docs/master/
 Disallow: /newsite/
+Disallow: /test-page.html
 
 User-agent: * 
 Crawl-Delay: 10

--- a/chapel-lang.org/test-page.html
+++ b/chapel-lang.org/test-page.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Test page</title>
+</head>
+<body>
+  <h1>Example page for Chapel networking tests</h1>
+  <p>Hello, world!</p>
+</body>
+</html>
+


### PR DESCRIPTION
Currently [one of our nightly tests](https://github.com/chapel-lang/chapel/blob/abb5257919418d4554556bba42986f5cbb60ebd5/test/library/packages/URL/doc-examples/example_read_url.chpl) retrieves the content of example.com and checks it is as expected. Since this page occasionally changes outside of our control, it causes random test failures. Add a very simple page to our website which we can use as replacement test fodder.

[reviewed by @bradcray , thanks!]