### PR TITLE
Rephrase reddit in 'other community forums' list

### DIFF
--- a/src/content/socials.md
+++ b/src/content/socials.md
@@ -32,7 +32,6 @@ your request.
 * [**YouTube**](https://www.youtube.com/@ChapelLanguage)
 {.content-paragraph}
 
-Beyond the channels above, we always appreciate seeing Chapel-related
-content on other community forums such as Reddit, HackerNews,
-Lobste.rs, etc.
+Beyond the channels above, we always appreciate seeing Chapel-related content
+on other community forums such as HackerNews, Lobste.rs, etc.
 {.content-paragraph}

--- a/src/content/socials.md
+++ b/src/content/socials.md
@@ -33,5 +33,5 @@ your request.
 {.content-paragraph}
 
 Beyond the channels above, we always appreciate seeing Chapel-related content
-on other community forums such as HackerNews, Lobste.rs, etc.
+on other community forums such as other subreddits, HackerNews, Lobste.rs, etc.
 {.content-paragraph}


### PR DESCRIPTION
It seems strange to me that Reddit is listed in the small "other community forums" note at the bottom of the socials page, since we have an official subreddit that is conspicuously listed above.

Changed to listing as "on other community forums such as other subreddits, HackerNews, [...]" so as not to exclude non r/chapel subreddits.

[reviewed by @bradcray , thanks!]