### PR TITLE
Enable dependabot version updates for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 15
+    assignees:
+      - "arifthpe"


### PR DESCRIPTION
Enable [Dependabot version updates](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configure-version-updates) for this repo, copying settings from https://github.com/chapel-lang/chapel.

[trivial, not reviewed]