### PR TITLE
Pin GitHub Actions versions to SHAs

### DIFF
--- a/.github/workflows/check-unused-artifacts.yaml
+++ b/.github/workflows/check-unused-artifacts.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout commits on PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 2
       - name: check for unused artifacts

--- a/.github/workflows/hugo-build.yml
+++ b/.github/workflows/hugo-build.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: install hugo
-        uses: peaceiris/actions-hugo@v3
+        uses: peaceiris/actions-hugo@2752ce1d29631191ea3f27c23495fa06139a5b78 # v3
         with:
           hugo-version: 'latest'
       - name: run make www

--- a/.github/workflows/lint-artifacts.yml
+++ b/.github/workflows/lint-artifacts.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: run artifacts linter
         run: |
           python ./src/util/lint_artifacts.py ./src/data/artifacts.toml


### PR DESCRIPTION
To be followed up with enabling the setting to only allow SHA-pinned Actions to run on this repo.

Used https://github.com/mheap/pin-github-action to do the pinning.

[trivial, not reviewed]