### PR TITLE
Use ubuntu-slim runner for all GA jobs

### DIFF
--- a/.github/workflows/check-unused-artifacts.yaml
+++ b/.github/workflows/check-unused-artifacts.yaml
@@ -4,7 +4,7 @@ on: pull_request
 
 jobs:
   check-unused-artifacts:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: checkout commits on PR branch
         uses: actions/checkout@v4

--- a/.github/workflows/hugo-build.yml
+++ b/.github/workflows/hugo-build.yml
@@ -5,7 +5,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   make-www:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: checkout
         uses: actions/checkout@v6

--- a/.github/workflows/lint-artifacts.yml
+++ b/.github/workflows/lint-artifacts.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Switch all jobs from running on `ubuntu-latest` to `ubuntu-slim`, since they are lightweight and do not benefit from having more CPU available.

[trivial, not reviewed]