### PR TITLE
Add workflow-linting (actionlint+zizmor) workflow

### DIFF
--- a/.github/workflows/check-unused-artifacts.yaml
+++ b/.github/workflows/check-unused-artifacts.yaml
@@ -16,6 +16,6 @@ jobs:
 
           # Just look at the merge commit created by the checkout action for
           # the PR.
-          git diff -U0 $GITHUB_SHA^1 $GITHUB_SHA > diff.txt
+          git diff -U0 "$GITHUB_SHA"^1 "$GITHUB_SHA" > diff.txt
           python ./src/util/check_unused_artifacts.py ./src/data/artifacts.toml diff.txt
 

--- a/.github/workflows/check-unused-artifacts.yaml
+++ b/.github/workflows/check-unused-artifacts.yaml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 2
+          persist-credentials: false
       - name: check for unused artifacts
         run: |
           # Just look at the merge commit created by the checkout action for

--- a/.github/workflows/check-unused-artifacts.yaml
+++ b/.github/workflows/check-unused-artifacts.yaml
@@ -2,6 +2,9 @@ name: check-unused-artifacts
 
 on: pull_request
 
+permissions:
+    contents: read
+
 defaults:
   run:
     shell: bash -exuo pipefail {0}

--- a/.github/workflows/hugo-build.yml
+++ b/.github/workflows/hugo-build.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: install hugo
         uses: peaceiris/actions-hugo@2752ce1d29631191ea3f27c23495fa06139a5b78 # v3
         with:

--- a/.github/workflows/hugo-build.yml
+++ b/.github/workflows/hugo-build.yml
@@ -2,6 +2,9 @@ name: hugo-build
 
 on: [push, pull_request, workflow_dispatch]
 
+permissions:
+    contents: read
+
 defaults:
   run:
     shell: bash -exuo pipefail {0}

--- a/.github/workflows/lint-artifacts.yml
+++ b/.github/workflows/lint-artifacts.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: run artifacts linter
         run: |
           python ./src/util/lint_artifacts.py ./src/data/artifacts.toml

--- a/.github/workflows/lint-artifacts.yml
+++ b/.github/workflows/lint-artifacts.yml
@@ -15,6 +15,9 @@ on:
       - ".github/**"
   workflow_dispatch:
 
+permissions:
+    contents: read
+
 defaults:
   run:
     shell: bash -exuo pipefail {0}

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   pull_request:
 
+permissions:
+    contents: read
+
 defaults:
   run:
     shell: bash -exuo pipefail {0}

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,65 @@
+name: lint workflows
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  merge_group:
+
+permissions:
+  contents: read
+  packages: read
+
+defaults:
+  run:
+    shell: bash -exuo pipefail {0}
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-slim
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        sparse-checkout: .github
+        persist-credentials: false
+    - name: Download actionlint
+      id: get_actionlint
+      run: |
+        wget https://raw.githubusercontent.com/rhysd/actionlint/main/.github/actionlint-matcher.json
+        echo "::add-matcher::./actionlint-matcher.json"
+        bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+      shell: bash
+    - name: Check workflow files
+      run: |
+        # ignore is to work around https://github.com/rhysd/actionlint/issues/657
+        ${STEPS_GET_ACTIONLINT_OUTPUTS_EXECUTABLE} -color -ignore 'unexpected key \"queue\" for \"concurrency\" section'
+      shell: bash
+      env:
+        STEPS_GET_ACTIONLINT_OUTPUTS_EXECUTABLE: ${{ steps.get_actionlint.outputs.executable }}
+
+  zizmor:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        sparse-checkout: .github
+        persist-credentials: false
+    - name: Run zizmor
+      uses: zizmorcore/zizmor-action@6599ee8b7a49aef6a770f63d261d214911a7ce02 # v0.6.0
+      with:
+        advanced-security: false
+        inputs: |
+          .github/workflows
+
+  # Canary for any linter failures
+  linters-alert-failure:
+    if: ${{ cancelled() || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
+    runs-on: ubuntu-slim
+    needs:
+      - actionlint
+      - zizmor
+    steps:
+      - name: Fail
+        run: |
+          echo "A required status check has failed"
+          exit 1

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -4,11 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-  merge_group:
-
-permissions:
-  contents: read
-  packages: read
 
 defaults:
   run:
@@ -31,8 +26,7 @@ jobs:
       shell: bash
     - name: Check workflow files
       run: |
-        # ignore is to work around https://github.com/rhysd/actionlint/issues/657
-        ${STEPS_GET_ACTIONLINT_OUTPUTS_EXECUTABLE} -color -ignore 'unexpected key \"queue\" for \"concurrency\" section'
+        ${STEPS_GET_ACTIONLINT_OUTPUTS_EXECUTABLE} -color
       shell: bash
       env:
         STEPS_GET_ACTIONLINT_OUTPUTS_EXECUTABLE: ${{ steps.get_actionlint.outputs.executable }}
@@ -50,16 +44,3 @@ jobs:
         advanced-security: false
         inputs: |
           .github/workflows
-
-  # Canary for any linter failures
-  linters-alert-failure:
-    if: ${{ cancelled() || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
-    runs-on: ubuntu-slim
-    needs:
-      - actionlint
-      - zizmor
-    steps:
-      - name: Fail
-        run: |
-          echo "A required status check has failed"
-          exit 1


### PR DESCRIPTION
Add a workflow which lints all our GitHub Actions workflows with https://github.com/rhysd/actionlint and https://github.com/zizmorcore/zizmor.

Modeled after the workflow in https://github.com/chapel-lang/chapel/blob/f8d552424219df061c18fe373112308340070209/.github/workflows/lint-workflows.yml .

[trivial, not reviewed]