### PR TITLE
Sparse-checkout src/ dir in all GA workflows

### DIFF
--- a/.github/workflows/check-unused-artifacts.yaml
+++ b/.github/workflows/check-unused-artifacts.yaml
@@ -10,6 +10,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
+          sparse-checkout: src/
       - name: check for unused artifacts
         run: |
           #!/usr/bin/env bash

--- a/.github/workflows/hugo-build.yml
+++ b/.github/workflows/hugo-build.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v6
+        with:
+          sparse-checkout: src/
       - name: install hugo
         uses: peaceiris/actions-hugo@v3
         with:

--- a/.github/workflows/lint-artifacts.yml
+++ b/.github/workflows/lint-artifacts.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          sparse-checkout: src/
       - name: run artifacts linter
         run: |
           python ./src/util/lint_artifacts.py ./src/data/artifacts.toml


### PR DESCRIPTION
This seems to be adequate for all the workflows to work properly, while checking out a much smaller slice of the repo.

The diff in the `hugo-build` workflow seems to work properly, despite the repo being in a strange state where it notices changes in files that were not originally checked out. It does not include the typical set of deleted files (papers and presentations) which are now never checked out to be deleted by rsync in the first place.

[reviewer info placeholder]