### PR TITLE
Fix "By Category" listing I broke and unify title

### DIFF
--- a/src/content/resources.md
+++ b/src/content/resources.md
@@ -1,5 +1,5 @@
 +++
-title = "Resources"
+title = "Talks & Papers"
 description = "Highlighted Chapel papers and presentations with links to more complete lists"
 keywords = ["TODO"]
 +++

--- a/src/layouts/_shortcodes/publication-categories.html
+++ b/src/layouts/_shortcodes/publication-categories.html
@@ -1,4 +1,4 @@
-{{ range where $.Site.Menus.main "Name" "Resources" }}
+{{ range where $.Site.Menus.main "Name" "Talks & Papers" }}
  <ul>
  {{ range .Children.ByWeight }}
    <li><a href="{{ .URL }}">{{ .Name }}</a></li>


### PR DESCRIPTION
I only just realized that I broke the "By Category" listing on the `/resources/` page on the website when I renamed the menu bar from "Resources" to "Talks & Papers" in https://github.com/chapel-lang/chapel-www/pull/115.  In addition to fixing that, this PR makes the title match the menu name now.